### PR TITLE
fixed index for writing resolutions

### DIFF
--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -1039,6 +1039,8 @@ steelseries_write_resolutions_v4(struct ratbag_profile *profile)
 			&buf[index * 2 + 4],
 			resolution->dpi_x / dpirange->step
 		);
+
+		index++;
 	}
 
 	return ratbag_hidraw_output_report(profile->device, buf, sizeof(buf));


### PR DESCRIPTION
It seems you forgot to increment the index variable at configuring the dpi settings. With this commit the mouse could be configured easily with piper and all my tests are therefore completed.

What do you think about unit tests? Are these applicable or even desirable on a project like libratbag?